### PR TITLE
Split inconsistent name and ref suggestions

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1,4 +1,4 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/Users/aaron/to_fix/js/bing.js":[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/home/patrick/Code/to-fix/js/bing.js":[function(require,module,exports){
 module.exports = L.TileLayer.extend({
     options: {
         subdomains: [0, 1, 2, 3],
@@ -118,7 +118,7 @@ module.exports = L.TileLayer.extend({
     }
 });
 
-},{}],"/Users/aaron/to_fix/js/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/js/index.js":[function(require,module,exports){
 var querystring = require('querystring'),
     omnivore = require('leaflet-omnivore'),
     BingLayer = require('./bing.js'),
@@ -187,8 +187,11 @@ var tasks = {
     'northeast_highway_intersects_building': {
         title: 'Highway/building overlap',
         loader: nyc_overlaps },
-    'inconsistent': {
+    'inconsistent_name': {
         title: 'Inconsistent street names',
+        loader: inconsistent },
+    'inconsistent_ref': {
+        title: 'Inconsistent street refs',
         loader: inconsistent },
     'npsdiff': {
         loader: npsdiff }
@@ -472,7 +475,7 @@ function inconsistent() {
 
     renderUI({
         title: tasks[qs('error')].title,
-        name: current.name || current.ref
+        name: current.tag_suggestion
     });
 }
 
@@ -585,7 +588,7 @@ function qs(name) {
     return querystring.parse(window.location.search.slice(1))[name];
 }
 
-},{"./bing.js":"/Users/aaron/to_fix/js/bing.js","leaflet-omnivore":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/index.js","mousetrap":"/Users/aaron/to_fix/node_modules/mousetrap/mousetrap.js","osm-auth":"/Users/aaron/to_fix/node_modules/osm-auth/index.js","querystring":"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/index.js","store":"/Users/aaron/to_fix/node_modules/store/store.js"}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/index.js":[function(require,module,exports){
+},{"./bing.js":"/home/patrick/Code/to-fix/js/bing.js","leaflet-omnivore":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/index.js","mousetrap":"/home/patrick/Code/to-fix/node_modules/mousetrap/mousetrap.js","osm-auth":"/home/patrick/Code/to-fix/node_modules/osm-auth/index.js","querystring":"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/index.js","store":"/home/patrick/Code/to-fix/node_modules/store/store.js"}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/index.js":[function(require,module,exports){
 var xhr = require('corslite'),
     csv2geojson = require('csv2geojson'),
     wellknown = require('wellknown'),
@@ -806,7 +809,7 @@ function parseXML(str) {
     }
 }
 
-},{"corslite":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/corslite/corslite.js","csv2geojson":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/index.js","togeojson":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/togeojson/togeojson.js","topojson/topojson.js":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/topojson/topojson.js","wellknown":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/wellknown/index.js"}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/corslite/corslite.js":[function(require,module,exports){
+},{"corslite":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/corslite/corslite.js","csv2geojson":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/index.js","togeojson":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/togeojson/togeojson.js","topojson/topojson.js":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/topojson/topojson.js","wellknown":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/wellknown/index.js"}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/corslite/corslite.js":[function(require,module,exports){
 function corslite(url, callback, cors) {
     var sent = false;
 
@@ -901,7 +904,7 @@ function corslite(url, callback, cors) {
 
 if (typeof module !== 'undefined') module.exports = corslite;
 
-},{}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/index.js":[function(require,module,exports){
 var dsv = require('dsv'),
     sexagesimal = require('sexagesimal');
 
@@ -1088,12 +1091,12 @@ module.exports = {
     toPolygon: toPolygon
 };
 
-},{"dsv":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/dsv/index.js","sexagesimal":"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/sexagesimal/index.js"}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/dsv/index.js":[function(require,module,exports){
+},{"dsv":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/dsv/index.js","sexagesimal":"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/sexagesimal/index.js"}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/dsv/index.js":[function(require,module,exports){
 
 
 module.exports = new Function("dsv.version = \"0.0.3\";\n\ndsv.tsv = dsv(\"\\t\");\ndsv.csv = dsv(\",\");\n\nfunction dsv(delimiter) {\n  var dsv = {},\n      reFormat = new RegExp(\"[\\\"\" + delimiter + \"\\n]\"),\n      delimiterCode = delimiter.charCodeAt(0);\n\n  dsv.parse = function(text, f) {\n    var o;\n    return dsv.parseRows(text, function(row, i) {\n      if (o) return o(row, i - 1);\n      var a = new Function(\"d\", \"return {\" + row.map(function(name, i) {\n        return JSON.stringify(name) + \": d[\" + i + \"]\";\n      }).join(\",\") + \"}\");\n      o = f ? function(row, i) { return f(a(row), i); } : a;\n    });\n  };\n\n  dsv.parseRows = function(text, f) {\n    var EOL = {}, // sentinel value for end-of-line\n        EOF = {}, // sentinel value for end-of-file\n        rows = [], // output rows\n        N = text.length,\n        I = 0, // current character index\n        n = 0, // the current line number\n        t, // the current token\n        eol; // is the current token followed by EOL?\n\n    function token() {\n      if (I >= N) return EOF; // special case: end of file\n      if (eol) return eol = false, EOL; // special case: end of line\n\n      // special case: quotes\n      var j = I;\n      if (text.charCodeAt(j) === 34) {\n        var i = j;\n        while (i++ < N) {\n          if (text.charCodeAt(i) === 34) {\n            if (text.charCodeAt(i + 1) !== 34) break;\n            ++i;\n          }\n        }\n        I = i + 2;\n        var c = text.charCodeAt(i + 1);\n        if (c === 13) {\n          eol = true;\n          if (text.charCodeAt(i + 2) === 10) ++I;\n        } else if (c === 10) {\n          eol = true;\n        }\n        return text.substring(j + 1, i).replace(/\"\"/g, \"\\\"\");\n      }\n\n      // common case: find next delimiter or newline\n      while (I < N) {\n        var c = text.charCodeAt(I++), k = 1;\n        if (c === 10) eol = true; // \\n\n        else if (c === 13) { eol = true; if (text.charCodeAt(I) === 10) ++I, ++k; } // \\r|\\r\\n\n        else if (c !== delimiterCode) continue;\n        return text.substring(j, I - k);\n      }\n\n      // special case: last token before EOF\n      return text.substring(j);\n    }\n\n    while ((t = token()) !== EOF) {\n      var a = [];\n      while (t !== EOL && t !== EOF) {\n        a.push(t);\n        t = token();\n      }\n      if (f && !(a = f(a, n++))) continue;\n      rows.push(a);\n    }\n\n    return rows;\n  };\n\n  dsv.format = function(rows) {\n    if (Array.isArray(rows[0])) return dsv.formatRows(rows); // deprecated; use formatRows\n    var fieldSet = {}, fields = [];\n\n    // Compute unique fields in order of discovery.\n    rows.forEach(function(row) {\n      for (var field in row) {\n        if (!(field in fieldSet)) {\n          fields.push(fieldSet[field] = field);\n        }\n      }\n    });\n\n    return [fields.map(formatValue).join(delimiter)].concat(rows.map(function(row) {\n      return fields.map(function(field) {\n        return formatValue(row[field]);\n      }).join(delimiter);\n    })).join(\"\\n\");\n  };\n\n  dsv.formatRows = function(rows) {\n    return rows.map(formatRow).join(\"\\n\");\n  };\n\n  function formatRow(row) {\n    return row.map(formatValue).join(delimiter);\n  }\n\n  function formatValue(text) {\n    return reFormat.test(text) ? \"\\\"\" + text.replace(/\\\"/g, \"\\\"\\\"\") + \"\\\"\" : text;\n  }\n\n  return dsv;\n}\n" + ";return dsv")();
 
-},{}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/sexagesimal/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/csv2geojson/node_modules/sexagesimal/index.js":[function(require,module,exports){
 module.exports = function(x, dims) {
     if (!dims) dims = 'NSEW';
     if (typeof x !== 'string') return null;
@@ -1107,7 +1110,7 @@ module.exports = function(x, dims) {
         ((m[4] && m[4] === 'S' || m[4] === 'W') ? -1 : 1);
 };
 
-},{}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/togeojson/togeojson.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/togeojson/togeojson.js":[function(require,module,exports){
 (function (process){
 toGeoJSON = (function() {
     'use strict';
@@ -1346,7 +1349,7 @@ toGeoJSON = (function() {
 if (typeof module !== 'undefined') module.exports = toGeoJSON;
 
 }).call(this,require('_process'))
-},{"_process":"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js","xmldom":"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/browser-resolve/empty.js"}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/topojson/topojson.js":[function(require,module,exports){
+},{"_process":"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js","xmldom":"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/browser-resolve/empty.js"}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/topojson/topojson.js":[function(require,module,exports){
 !function() {
   var topojson = {
     version: "1.6.8",
@@ -1880,7 +1883,7 @@ if (typeof module !== 'undefined') module.exports = toGeoJSON;
   else this.topojson = topojson;
 }();
 
-},{}],"/Users/aaron/to_fix/node_modules/leaflet-omnivore/node_modules/wellknown/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/leaflet-omnivore/node_modules/wellknown/index.js":[function(require,module,exports){
 module.exports = parse;
 module.exports.parse = parse;
 module.exports.stringify = stringify;
@@ -2129,7 +2132,7 @@ function stringify(gj) {
     }
 }
 
-},{}],"/Users/aaron/to_fix/node_modules/mousetrap/mousetrap.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/mousetrap/mousetrap.js":[function(require,module,exports){
 /**
  * Copyright 2012 Craig Campbell
  *
@@ -2930,7 +2933,7 @@ function stringify(gj) {
 module.exports = mousetrap;
 
 
-},{}],"/Users/aaron/to_fix/node_modules/osm-auth/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/osm-auth/index.js":[function(require,module,exports){
 'use strict';
 
 var ohauth = require('ohauth'),
@@ -3190,7 +3193,7 @@ module.exports = function(o) {
     return oauth;
 };
 
-},{"ohauth":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/ohauth/index.js","store":"/Users/aaron/to_fix/node_modules/store/store.js","xtend":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/index.js"}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/ohauth/index.js":[function(require,module,exports){
+},{"ohauth":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/ohauth/index.js","store":"/home/patrick/Code/to-fix/node_modules/store/store.js","xtend":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/index.js"}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/ohauth/index.js":[function(require,module,exports){
 'use strict';
 
 var hashes = require('jshashes'),
@@ -3329,7 +3332,7 @@ ohauth.headerGenerator = function(options) {
 
 module.exports = ohauth;
 
-},{"jshashes":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/ohauth/node_modules/jshashes/hashes.js","xtend":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/index.js"}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/ohauth/node_modules/jshashes/hashes.js":[function(require,module,exports){
+},{"jshashes":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/ohauth/node_modules/jshashes/hashes.js","xtend":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/index.js"}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/ohauth/node_modules/jshashes/hashes.js":[function(require,module,exports){
 (function (global){
 /**
  * jshashes - https://github.com/h2non/jshashes
@@ -5098,7 +5101,7 @@ module.exports = ohauth;
 }()); // IIFE
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/has-keys.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/has-keys.js":[function(require,module,exports){
 module.exports = hasKeys
 
 function hasKeys(source) {
@@ -5107,7 +5110,7 @@ function hasKeys(source) {
         typeof source === "function")
 }
 
-},{}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/index.js":[function(require,module,exports){
 var Keys = require("object-keys")
 var hasKeys = require("./has-keys")
 
@@ -5134,11 +5137,11 @@ function extend() {
     return target
 }
 
-},{"./has-keys":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/has-keys.js","object-keys":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/index.js"}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/index.js":[function(require,module,exports){
+},{"./has-keys":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/has-keys.js","object-keys":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/index.js"}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/index.js":[function(require,module,exports){
 module.exports = Object.keys || require('./shim');
 
 
-},{"./shim":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/shim.js"}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/foreach/index.js":[function(require,module,exports){
+},{"./shim":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/shim.js"}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/foreach/index.js":[function(require,module,exports){
 
 var hasOwn = Object.prototype.hasOwnProperty;
 var toString = Object.prototype.toString;
@@ -5162,7 +5165,7 @@ module.exports = function forEach (obj, fn, ctx) {
 };
 
 
-},{}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/is/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/is/index.js":[function(require,module,exports){
 
 /**!
  * is
@@ -5866,7 +5869,7 @@ is.string = function (value) {
 };
 
 
-},{}],"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/shim.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/shim.js":[function(require,module,exports){
 (function () {
 	"use strict";
 
@@ -5912,7 +5915,7 @@ is.string = function (value) {
 }());
 
 
-},{"foreach":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/foreach/index.js","is":"/Users/aaron/to_fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/is/index.js"}],"/Users/aaron/to_fix/node_modules/store/store.js":[function(require,module,exports){
+},{"foreach":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/foreach/index.js","is":"/home/patrick/Code/to-fix/node_modules/osm-auth/node_modules/xtend/node_modules/object-keys/node_modules/is/index.js"}],"/home/patrick/Code/to-fix/node_modules/store/store.js":[function(require,module,exports){
 ;(function(win){
 	var store = {},
 		doc = win.document,
@@ -6081,9 +6084,9 @@ is.string = function (value) {
 
 })(Function('return this')());
 
-},{}],"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/browser-resolve/empty.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/browser-resolve/empty.js":[function(require,module,exports){
 
-},{}],"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/process/browser.js":[function(require,module,exports){
 // shim for using process in browser
 
 var process = module.exports = {};
@@ -6148,7 +6151,7 @@ process.chdir = function (dir) {
     throw new Error('process.chdir is not supported');
 };
 
-},{}],"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/decode.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/decode.js":[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -6234,7 +6237,7 @@ var isArray = Array.isArray || function (xs) {
   return Object.prototype.toString.call(xs) === '[object Array]';
 };
 
-},{}],"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/encode.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/encode.js":[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -6285,7 +6288,7 @@ module.exports = function(obj, sep, eq, name) {
     return map(objectKeys(obj), function(k) {
       var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
       if (isArray(obj[k])) {
-        return map(obj[k], function(v) {
+        return obj[k].map(function(v) {
           return ks + encodeURIComponent(stringifyPrimitive(v));
         }).join(sep);
       } else {
@@ -6321,10 +6324,10 @@ var objectKeys = Object.keys || function (obj) {
   return res;
 };
 
-},{}],"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/index.js":[function(require,module,exports){
+},{}],"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/index.js":[function(require,module,exports){
 'use strict';
 
 exports.decode = exports.parse = require('./decode');
 exports.encode = exports.stringify = require('./encode');
 
-},{"./decode":"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/decode.js","./encode":"/Users/aaron/to_fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/encode.js"}]},{},["/Users/aaron/to_fix/js/index.js"]);
+},{"./decode":"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/decode.js","./encode":"/home/patrick/Code/to-fix/node_modules/watchify/node_modules/browserify/node_modules/querystring-es3/encode.js"}]},{},["/home/patrick/Code/to-fix/js/index.js"]);

--- a/js/index.js
+++ b/js/index.js
@@ -66,8 +66,11 @@ var tasks = {
     'northeast_highway_intersects_building': {
         title: 'Highway/building overlap',
         loader: nyc_overlaps },
-    'inconsistent': {
+    'inconsistent_name': {
         title: 'Inconsistent street names',
+        loader: inconsistent },
+    'inconsistent_ref': {
+        title: 'Inconsistent street refs',
         loader: inconsistent },
     'npsdiff': {
         loader: npsdiff }
@@ -351,7 +354,7 @@ function inconsistent() {
 
     renderUI({
         title: tasks[qs('error')].title,
-        name: current.name || current.ref
+        name: current.tag_suggestion
     });
 }
 


### PR DESCRIPTION
After working with this a little bit, it makes more sense to split name and ref suggestions. Then you don't need to figure out which tag is inconsistent.

The updated dataset can be found here:

https://www.dropbox.com/s/z46rje19pmrkdvm/inconsistent.tar.gz?dl=0

The updated version of streetname-fixer also filters closed ways and checks if ```before_way_id != after_way_id``` to filter out some false-positives with roundabouts.