### PR TITLE
avoid geoJSON loading race condition. speed improvement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "levelup": "^0.18.6",
     "mousetrap": "0.0.1",
     "osm-auth": "^0.2.6",
+    "queue-async": "^1.0.7",
     "routes-router": "^3.1.0",
     "serve": "^1.4.0",
     "store": "~1.3.16",

--- a/prioritize.js
+++ b/prioritize.js
@@ -3,47 +3,50 @@ var fs = require('fs'),
     gju = require('geojson-utils'),
     key = require('./lib/key.js'),
     levelup = require('levelup'),
-    wellknown = require('wellknown');
+    wellknown = require('wellknown'),
+    queue = require('queue-async');
 
-// adjusts skipvals based on geometry, prioritizing particular areas/markets
+// adjusts task skipvals based on geometry, prioritizing particular areas/markets
+
+var quickMode = true; // should we bother matching against every geometry or just quit after one hit?
 
 if (process.stdin.isTTY) {
-    var quickMode = true; // should we bother matching against every geometry or just quit after one hit?
-
     if (process.argv.length < 4) {
         return console.log('file arguments are required\n`node prioritize.js [task] [geojson1 geojson2 ... ]`');
     }
 
     // process command line params, load geojson files
+    var q = queue();
     var geojson = {};
     process.argv
+        .filter(function(elem, i) { return (i>2); })
         .forEach(function(elem, i) {
-            if (i <= 2) {
-                // skip require params -- choosing not to use .filter() to make async logic simpler below
-                return true;
-            }
-
-            // if using overlapping geojson files, this flag might be useful. otherwise, no.
+            // if using overlapping geojson files, this flag might be useful. 
+            // otherwise, no.
             if (elem === '--slow') {
                 quickMode = false;
-            } else {
-                var basename = path.basename(elem, '.geojson');
-
-                fs.readFile(elem, function(err, data) {
-                    if (err) console.log('# Error loading GeoJSON file ' + elem);
-                    var boundary = JSON.parse(data);
-                    if ((boundary === null) || !boundary.features) {
-                        console.log('# failed to load valid GeoJSON from ' + elem);
-                    } else {
-                        geojson[basename] = boundary;  
-                        console.log('- loaded GeoJSON file ' + elem);  
-                    }
-                    
-                    // if all params have been loaded, begin main processing
-                    if(i === process.argv.length-1) ProcessLevelDB();
-                });
+            } else {                
+                q.defer(loadGeoJSON, elem);              
             }
         });
+
+    q.awaitAll(ProcessLevelDB);
+}
+
+function loadGeoJSON(elem, callback) {
+    fs.readFile(elem, function(err, data) {
+        if (err) console.log('# Error loading GeoJSON file ' + elem);
+
+        var basename = path.basename(elem);
+        var boundary = JSON.parse(data);
+        if ((boundary === null) || !boundary.features) {
+            console.log('# failed to load valid GeoJSON from ' + elem);
+        } else {
+            geojson[basename] = boundary;  
+            console.log('- loaded GeoJSON file ' + elem);  
+        }    
+        callback();
+    });
 }
 
 function ProcessLevelDB(){
@@ -55,6 +58,7 @@ function ProcessLevelDB(){
         console.log('- checking for geometry overlap');
         db.createReadStream()
             .on('data', function(data) {
+
                 data.value = JSON.parse(data.value);
 
                 // if this task is already fixed, skip it
@@ -62,23 +66,29 @@ function ProcessLevelDB(){
 
                 // check if point is in any geojson geometries
                 var overlapCount = 0;
-                Object.keys(geojson).forEach(function(k) {
+                Object.keys(geojson).every(function(k) {
+                    
+                    // check for valid point geometry in the task object
                     if (!data.value.st_astext) {
                         console.log('# missing geometry (st_astext) for key ' + data.key);
                         return false;
                     } 
 
+                    // test for presence of point in polygon
                     if (gju.pointInPolygon(wellknown.parse(data.value.st_astext), geojson[k].features[0].geometry)) {
                         if (!data.value.priority) data.value.priority = []; 
                         data.value.priority.push(k);
                         overlapCount++;
                         if (quickMode) return false;
                     }
+
+                    return true;
                 });
 
                 // track maximum number of overlaps
                 maxOverlaps = Math.max(maxOverlaps, overlapCount);
 
+                // record findings in the task object record
                 data.value.overlapCount = overlapCount;
                 db.put(data.key, JSON.stringify(data.value), function(err) {
                     if (err) console.log('# error saving key ' + data.key + '#' + overlapCount);
@@ -94,10 +104,13 @@ function ProcessLevelDB(){
                 db.createReadStream()
                     .on('data', function(data) {
                         data.value = JSON.parse(data.value);
+
+                        // increment skipval based on number of overlaps
                         var keyComponents = key.decompose(data.key);
                         var newKey = key.compose((keyComponents.skipval + (maxOverlaps - parseInt(data.value.overlapCount))), keyComponents.hash);
                         if (parseInt(data.value.overlapCount) > 0) adjustmentsMade++;
 
+                        // rename the task ID to reflect the new skipval
                         delete data.value.overlapCount;
                         db.del(data.key, function(err){
                             if (err) console.log('# error deleting key ' + newKey);


### PR DESCRIPTION
- if geoJSON files specified later in argv loaded too quickly, processing might begin before earlier files had finished loading
- Array.forEach() doesn't break when you return false; .every() does. Failing to realize this meant that every geoJSON boundary was tested against every task, instead of the loop exiting after the first match (by default). This was equivalent to the --slow flag always being set. Matching tasks are a small percentage of overall tasks so this does not produce a dramatic speed increase, but it is the originally intended behavior and should help somewhat.
