### PR TITLE
Show the edit bar when using iD, fixes #165

### DIFF
--- a/src/components/task/edit_bar.js
+++ b/src/components/task/edit_bar.js
@@ -102,7 +102,7 @@ let EditBar = React.createClass({
     }
 
     return (
-      <div className='editbar pin-bottomleft col6 pad4 z1 margin3'>
+      <div className='editbar pin-bottomleft col6 pad4 z10000 margin3'>
         <div className='round col12'>
           {taskActions}
           <div className='fill-lighten3 round-bottom col12 pad2x pad1y center strong inline truncate'>

--- a/src/components/task/index.js
+++ b/src/components/task/index.js
@@ -77,12 +77,12 @@ class Task extends Component {
     }
   }
 
-  iDEditDone = () => {
+  reset = () => {
     this.setState({
       iDEdit: false,
       iDEditPath: '',
+      geolocation: '',
     });
-    this.fetchNextItem();
   }
 
   fetchNextItem = () => {
@@ -93,7 +93,7 @@ class Task extends Component {
     };
 
     fetchRandomItem({ taskId: currentTaskId, taskType: currentTaskType, payload })
-      .then(() => this.setState({ geolocation: null }));
+      .then(this.reset);
   }
 
   geolocate = (center) => {
@@ -255,17 +255,17 @@ class Task extends Component {
         geolocation={geolocation} />
     );
 
+    const iDContainerClass = iDEdit ? '' : 'hidden';
     const iDEditor = (
-      <div>
+      <div className={iDContainerClass}>
         <iframe src={iDEditPath} frameBorder='0' className='ideditor'></iframe>
-        <button onClick={this.iDEditDone} className='ideditor-done z10000 button rcon next round animate pad1y pad2x strong'>Next task</button>
       </div>
     );
 
     return (
       <div ref={node => this.mapContainer = node} className='mode active map fill-navy-dark contain'>
         { currentItemId && editBar }
-        { iDEdit && iDEditor }
+        { iDEditor }
       </div>
     );
   }


### PR DESCRIPTION
<img width="1067" alt="screen shot 2017-02-08 at 4 54 48 pm" src="https://cloud.githubusercontent.com/assets/11095038/22735362/61ec337e-ee1f-11e6-8d1b-09c01083b559.png">

Removes the "next task" button and always shows the edit bar.

cc: @Rub21 @rasagy 