### PR TITLE
Move login to header

### DIFF
--- a/public/site.css
+++ b/public/site.css
@@ -64,7 +64,7 @@ h2 { padding-top:0; padding-bottom:0; }
     line-height:20px;
     padding:5px 10px;
     font-weight:bold;
-    height:30px;
+    height:34px;
     }
 
 .loading:before {
@@ -142,7 +142,7 @@ header .fancy.title {
   color:rgba(0,0,0,0.75);
   }
 
-header .button {
+header nav .button {
   background-color:transparent;
   color:rgba(0,0,0,0.5);
   }
@@ -152,6 +152,12 @@ header .button {
     }
   header .button.active {
     color:#fff;
+    }
+  header a {
+    color:#6E65B3;
+    }
+  header a:hover {
+    color:#26198A;
     }
 
 .sidebar-toggle:hover,
@@ -180,8 +186,9 @@ header .button {
   }
 
 .avatar {
-  height:20px;
+  height:30px;
   margin-right:10px;
+  margin-top:-5px;
   }
 
 .progress-bar {
@@ -209,6 +216,46 @@ header .button {
   }
   .contributions > div:first-child { border-width:2px;  }
   .contributions > div:last-child { border-bottom:none; }
+
+  .user-menu {
+    position:relative;
+    top:7px;
+    right:0px;
+    padding:10px 0px 5px 0px;
+    border:1px solid rgba(26,53,71,.12);
+    border-radius:4px;
+    box-shadow:0 1px 2px rgba(26,53,71,.1);
+    opacity:0;
+    pointer-events:none;
+    -webkit-transform:scale(.8) translateY(-30%);
+    transform:scale(.8) translateY(-30%);
+    transition:.4s cubic-bezier(.3, 0, 0, 1.3);
+    background:white;
+    z-index:1000;
+    width:120px;
+    }
+
+  .user-menu.visible {
+    opacity:1;
+    pointer-events:auto;
+    -webkit-transform:none;
+    transform:none;
+    }
+
+  .user-menu::before {
+    content:"";
+    position:absolute;
+    top:-7px;
+    left:calc(50% - 7px);
+    width:13px;
+    height:7px;
+    background:url(user-menu-arrow.svg);
+    }
+
+  .user-menu li {
+    list-style:none;
+    text-align:left;
+    }
 
 /* iD container
  * elements while editing

--- a/public/user-menu-arrow.svg
+++ b/public/user-menu-arrow.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="13px" height="7px" viewBox="0 0 13 7" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <title>user-menu-arrow</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <path d="M6.49999999,0 L0,7 L13,7 L6.49999999,0 Z" id="Rectangle-83" fill="#D9DDE0" sketch:type="MSShapeGroup"></path>
+        <path d="M6.49999999,1 L1,7 L12,7 L6.49999999,1 Z" id="Rectangle-83" fill="#FFFFFF" sketch:type="MSShapeGroup"></path>
+    </g>
+</svg>

--- a/src/components/admin/index.js
+++ b/src/components/admin/index.js
@@ -1,7 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
+import { ROLES } from '../../constants/user_constants';
 import TasksSelectors from '../../stores/tasks_selectors';
+import UserSelectors from '../../stores/user_selectors';
 import TasksActionCreators from '../../stores/tasks_action_creators';
 
 import ShowTask from './show_task';
@@ -11,6 +13,8 @@ import AddTask from './add_task';
 const mapStateToProps = (state) => ({
   currentTaskId: TasksSelectors.getCurrentTaskId(state),
   currentTask: TasksSelectors.getCurrentTask(state),
+  isAuthenticated: UserSelectors.getIsAuthenticated(state),
+  role: UserSelectors.getRole(state),
 });
 
 const mapDispatchToProps = {
@@ -31,7 +35,23 @@ class Admin extends Component {
 
   render() {
     const { taskWindow } = this.state;
-    const { currentTask, updateTask, createTask } = this.props;
+    const { currentTask, updateTask, createTask, role, isAuthenticated } = this.props;
+
+    if (!isAuthenticated) {
+      return (
+        <div className='col12 pad2 clearfix scroll-styled'>
+          <h2 className='dark'>Please login to access the admin section.</h2>
+        </div>
+      );
+    }
+
+    if (role == ROLES.EDITOR) {
+      return (
+        <div className='col12 pad2 clearfix scroll-styled'>
+          <h2 className='dark'>You need admin privileges to see this section.</h2>
+        </div>
+      );
+    }
 
     return (
       <div className='col12 clearfix scroll-styled'>
@@ -55,6 +75,8 @@ class Admin extends Component {
 Admin.propTypes = {
   currentTaskId: PropTypes.string.isRequired,
   currentTask: PropTypes.object.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
+  role: PropTypes.string,
   createTask: PropTypes.func.isRequired,
   updateTask: PropTypes.func.isRequired,
 };

--- a/src/components/app/app_header.js
+++ b/src/components/app/app_header.js
@@ -6,6 +6,8 @@ import SettingsActionCreators from '../../stores/settings_action_creators';
 import SettingsSelectors from '../../stores/settings_selectors';
 import TasksSelectors from '../../stores/tasks_selectors';
 
+import Login from '../shared/login';
+
 const mapStateToProps = (state) => ({
   currentTaskId: TasksSelectors.getCurrentTaskId(state),
   sidebar: SettingsSelectors.getSidebarSetting(state),
@@ -37,8 +39,8 @@ class Header extends Component {
             <h1 className='inline fancy title'>to-fix</h1>
           </a>
         </nav>
-        <div className='col6 truncate text-right pad1'>
-          <nav className='col12 space pad0y'>
+        <div className='col4 truncate text-right pad1'>
+          <nav className='col12 space pad0y keyline-right'>
             <Link
               className='icon pencil short button'
               activeClassName='active'
@@ -57,13 +59,10 @@ class Header extends Component {
               to={`stats/${currentTaskId}`}>
               Statistics
             </Link>
-            <Link
-              className='icon plus short button'
-              activeClassName='active'
-              to={`admin/${currentTaskId}`}>
-              Admin
-            </Link>
           </nav>
+        </div>
+        <div className='col2 truncate pad1'>
+          <Login />
         </div>
       </header>
     );

--- a/src/components/app/app_sidebar.js
+++ b/src/components/app/app_sidebar.js
@@ -5,8 +5,6 @@ import { connect } from 'react-redux';
 import TasksSelectors from '../../stores/tasks_selectors';
 import SettingsSelectors from '../../stores/settings_selectors';
 
-import Login from '../shared/login';
-
 const mapStateToProps = (state, { routes }) => ({
   topLevelRoute: routes[1].name,
   sidebar: SettingsSelectors.getSidebarSetting(state),
@@ -45,7 +43,6 @@ class Sidebar extends Component {
     return (
       <div className={sidebarClass}>
         <div className='scroll-styled pad2y'>
-          <Login />
           <h4 className='dark block pad1x space-bottom1'>Current Tasks</h4>
           <nav className='dark space-bottom2'>{activeTasksList}</nav>
           <h4 className='dark block pad1x space-bottom1'>Completed Tasks</h4>

--- a/src/components/shared/settings_modal.js
+++ b/src/components/shared/settings_modal.js
@@ -4,19 +4,15 @@ import { connect } from 'react-redux';
 
 import SettingsSelectors from '../../stores/settings_selectors';
 import ModalsSelectors from '../../stores/modals_selectors';
-import UserSelectors from '../../stores/user_selectors';
-import UserActionCreators from '../../stores/user_action_creators';
 import SettingsActionCreators from '../../stores/settings_action_creators';
 import ModalsActionCreators from '../../stores/modals_action_creators';
 
 const mapStateToProps = (state) => ({
   editor: SettingsSelectors.getEditorSetting(state),
-  token: UserSelectors.getToken(state),
   showSettingsModal: ModalsSelectors.getShowSettingsModal(state),
 });
 
 const mapDispatchToProps = {
-  logout: UserActionCreators.logout,
   setEditorPreference: SettingsActionCreators.setEditorPreference,
   closeSettingsModal: ModalsActionCreators.closeSettingsModal,
 };
@@ -24,9 +20,7 @@ const mapDispatchToProps = {
 let SettingsModal = React.createClass({
   propTypes: {
     editor: PropTypes.string.isRequired,
-    token: PropTypes.string,
     showSettingsModal: PropTypes.bool.isRequired,
-    logout: PropTypes.func.isRequired,
     setEditorPreference: PropTypes.func.isRequired,
     closeSettingsModal: PropTypes.func.isRequired,
   },
@@ -37,13 +31,6 @@ let SettingsModal = React.createClass({
     'esc': function(e) {
       this.props.closeSettingsModal();
     },
-  },
-
-  logout(e) {
-    const { token } = this.props;
-
-    this.props.closeSettingsModal(e);
-    this.props.logout({ token });
   },
 
   setEditor(e) {
@@ -81,10 +68,6 @@ let SettingsModal = React.createClass({
             <div className='pad2x space-bottom2 dark'>
               Shortcut keys: <span className='quiet'><code className='fill-darken1'>e</code> Edit <code className='fill-darken1'>s</code> Skip <code className='fill-darken1'>n</code> Not an error <code className='fill-darken1'>f</code> Fixed</span>
               <small className='quiet'>*JOSM requires <a target='_blank' href='http://josm.openstreetmap.de/wiki/Help/Preferences/RemoteControl/'>remote control</a> to be set in preferences.</small>
-            </div>
-
-            <div className='pad2x pad1y fill-light round-bottom text-right'>
-              <button onClick={this.logout} className='rcon logout button quiet animate'>Logout</button>
             </div>
           </div>
         </div>

--- a/src/constants/user_constants.js
+++ b/src/constants/user_constants.js
@@ -7,3 +7,9 @@ const UserConstants = keymirror({
 });
 
 export default UserConstants;
+
+export const ROLES = {
+  EDITOR: 'editor',
+  ADMIN: 'admin',
+  SUPERADMIN: 'superadmin',
+};


### PR DESCRIPTION
- Move the login button to the header
- If logged in, show a popup menu on click
- Block the admin section if not logged in or does not have admin privileges
- Remove logout button from the settings modal

![to-fix](https://cloud.githubusercontent.com/assets/11095038/23402113/3f63de0e-fdd0-11e6-85c4-b4aaa3e6ebab.gif)

cc: @kepta @rasagy 